### PR TITLE
Add child theme with Slider and Crossroad Pages blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# wordpress-theme
+# WordPress Child Theme
+
+Ce dépôt contient un thème enfant du thème Twenty Twenty-Five. Il ajoute deux blocs Gutenberg personnalisés :
+
+- **Slider** : affiche un carrousel d'images ou de vidéos avec titre, description et bouton.
+- **Crossroad Pages** : liste de pages sélectionnées affichées sous forme de grille.
+
+## Installation
+
+1. Copier le dossier `twentytwentyfive-child` dans le répertoire `wp-content/themes` de votre installation WordPress.
+2. Activer le thème depuis l'administration WordPress.
+
+Les blocs sont alors disponibles depuis l'éditeur de blocs.

--- a/twentytwentyfive-child/blocks/crossroad-pages/block.json
+++ b/twentytwentyfive-child/blocks/crossroad-pages/block.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "twentytwentyfive-child/crossroad-pages",
+    "title": "Crossroad Pages",
+    "category": "widgets",
+    "icon": "grid-view",
+    "description": "Affiche une grille de liens vers des pages sélectionnées.",
+    "textdomain": "twentytwentyfive-child",
+    "editorScript": "file:./index.js",
+    "style": "file:./style.css",
+    "render": "file:./render.php",
+    "attributes": {
+        "pages": {
+            "type": "string",
+            "default": ""
+        }
+    }
+}

--- a/twentytwentyfive-child/blocks/crossroad-pages/index.js
+++ b/twentytwentyfive-child/blocks/crossroad-pages/index.js
@@ -1,0 +1,23 @@
+( function( blocks, element ) {
+    var el = element.createElement;
+    blocks.registerBlockType( 'twentytwentyfive-child/crossroad-pages', {
+        title: 'Crossroad Pages',
+        icon: 'grid-view',
+        category: 'widgets',
+        attributes: {
+            pages: { type: 'string', default: '' }
+        },
+        edit: function( props ) {
+            return el( 'input', {
+                type: 'text',
+                value: props.attributes.pages,
+                placeholder: 'IDs des pages séparées par une virgule',
+                onChange: function( event ) {
+                    props.setAttributes( { pages: event.target.value } );
+                },
+                style: { width: '100%' }
+            } );
+        },
+        save: function() { return null; }
+    } );
+} )( window.wp.blocks, window.wp.element );

--- a/twentytwentyfive-child/blocks/crossroad-pages/render.php
+++ b/twentytwentyfive-child/blocks/crossroad-pages/render.php
@@ -1,0 +1,28 @@
+<?php
+$ids = array_filter( array_map( 'intval', explode( ',', $attributes['pages'] ?? '' ) ) );
+if ( empty( $ids ) ) {
+    return '';
+}
+$query = new WP_Query( [
+    'post_type' => 'page',
+    'post__in'  => $ids,
+    'orderby'   => 'post__in',
+] );
+if ( ! $query->have_posts() ) {
+    return '';
+}
+ob_start();
+?>
+<div class="crossroad-pages">
+<?php while ( $query->have_posts() ) : $query->the_post(); ?>
+    <article class="crossroad-page">
+        <?php if ( has_post_thumbnail() ) : ?>
+            <a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'medium' ); ?></a>
+        <?php endif; ?>
+        <h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+    </article>
+<?php endwhile; ?>
+</div>
+<?php
+wp_reset_postdata();
+return ob_get_clean();

--- a/twentytwentyfive-child/blocks/crossroad-pages/style.css
+++ b/twentytwentyfive-child/blocks/crossroad-pages/style.css
@@ -1,0 +1,4 @@
+.crossroad-pages { display: flex; flex-wrap: wrap; gap: 1rem; }
+.crossroad-page { width: calc(33.333% - 1rem); box-sizing: border-box; }
+.crossroad-page img { width: 100%; height: auto; display: block; }
+.crossroad-page h2 { font-size: 1.25rem; margin-top: 0.5rem; }

--- a/twentytwentyfive-child/blocks/slider/block.json
+++ b/twentytwentyfive-child/blocks/slider/block.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "twentytwentyfive-child/slider",
+    "title": "Slider",
+    "category": "widgets",
+    "icon": "images-alt2",
+    "description": "Affiche un slider d'images ou vidéos.",
+    "textdomain": "twentytwentyfive-child",
+    "editorScript": "file:./index.js",
+    "script": "file:./slider.js",
+    "style": "file:./style.css",
+    "render": "file:./render.php",
+    "supports": {
+        "html": false
+    },
+    "attributes": {
+        "slides": {
+            "type": "array",
+            "default": []
+        }
+    }
+}

--- a/twentytwentyfive-child/blocks/slider/index.js
+++ b/twentytwentyfive-child/blocks/slider/index.js
@@ -1,0 +1,26 @@
+( function( blocks, element ) {
+    var el = element.createElement;
+    blocks.registerBlockType( 'twentytwentyfive-child/slider', {
+        title: 'Slider',
+        icon: 'images-alt2',
+        category: 'widgets',
+        attributes: {
+            slides: { type: 'array', default: [] }
+        },
+        edit: function( props ) {
+            var value = JSON.stringify( props.attributes.slides, null, 2 );
+            return el( 'textarea', {
+                value: value,
+                onChange: function( event ) {
+                    try {
+                        props.setAttributes( { slides: JSON.parse( event.target.value ) } );
+                    } catch ( e ) {}
+                },
+                style: { width: '100%', minHeight: '200px' }
+            } );
+        },
+        save: function() {
+            return null;
+        }
+    } );
+} )( window.wp.blocks, window.wp.element );

--- a/twentytwentyfive-child/blocks/slider/render.php
+++ b/twentytwentyfive-child/blocks/slider/render.php
@@ -1,0 +1,33 @@
+<?php
+$slides = $attributes['slides'] ?? [];
+if ( empty( $slides ) ) {
+    return '';
+}
+ob_start();
+?>
+<div class="slider-block">
+    <?php foreach ( $slides as $slide ) : ?>
+        <div class="slide">
+            <?php if ( isset( $slide['type'] ) && 'video' === $slide['type'] ) : ?>
+                <video src="<?php echo esc_url( $slide['url'] ); ?>" controls></video>
+            <?php else : ?>
+                <img src="<?php echo esc_url( $slide['url'] ); ?>" alt="<?php echo esc_attr( $slide['alt'] ?? '' ); ?>" />
+            <?php endif; ?>
+            <?php if ( ! empty( $slide['title'] ) ) : ?>
+                <h2><?php echo esc_html( $slide['title'] ); ?></h2>
+            <?php endif; ?>
+            <?php if ( ! empty( $slide['description'] ) ) : ?>
+                <p><?php echo esc_html( $slide['description'] ); ?></p>
+            <?php endif; ?>
+            <?php if ( ! empty( $slide['buttonText'] ) && ! empty( $slide['link'] ) ) : ?>
+                <a class="slide-button" href="<?php echo esc_url( $slide['link'] ); ?>">
+                    <?php echo esc_html( $slide['buttonText'] ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+    <?php endforeach; ?>
+    <button class="prev">&#171;</button>
+    <button class="next">&#187;</button>
+</div>
+<?php
+return ob_get_clean();

--- a/twentytwentyfive-child/blocks/slider/slider.js
+++ b/twentytwentyfive-child/blocks/slider/slider.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', function() {
+  document.querySelectorAll('.slider-block').forEach(function(slider){
+    var index = 0;
+    var slides = slider.querySelectorAll('.slide');
+    var prev = slider.querySelector('.prev');
+    var next = slider.querySelector('.next');
+    function show(i){
+      slides.forEach(function(s,idx){
+        s.style.display = idx === i ? 'block' : 'none';
+      });
+    }
+    function go(delta){
+      index = (index + delta + slides.length) % slides.length;
+      show(index);
+    }
+    if(prev){prev.addEventListener('click', function(){ go(-1); });}
+    if(next){next.addEventListener('click', function(){ go(1); });}
+    show(index);
+    setInterval(function(){ go(1); }, 5000);
+  });
+});

--- a/twentytwentyfive-child/blocks/slider/style.css
+++ b/twentytwentyfive-child/blocks/slider/style.css
@@ -1,0 +1,6 @@
+.slider-block { position: relative; overflow: hidden; }
+.slider-block .slide { display: none; }
+.slider-block .slide img, .slider-block .slide video { width: 100%; height: auto; }
+.slider-block .prev, .slider-block .next { position: absolute; top: 50%; transform: translateY(-50%); background: rgba(0,0,0,0.5); color: #fff; border: none; padding: 0.5em; cursor: pointer; }
+.slider-block .prev { left: 0; }
+.slider-block .next { right: 0; }

--- a/twentytwentyfive-child/functions.php
+++ b/twentytwentyfive-child/functions.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Theme functions and definitions.
+ */
+
+function twentytwentyfive_child_enqueue_styles() {
+    wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
+}
+add_action( 'wp_enqueue_scripts', 'twentytwentyfive_child_enqueue_styles' );
+
+/**
+ * Register custom blocks.
+ */
+function twentytwentyfive_child_register_blocks() {
+    $blocks = [ 'slider', 'crossroad-pages' ];
+    foreach ( $blocks as $block ) {
+        register_block_type( __DIR__ . '/blocks/' . $block );
+    }
+}
+add_action( 'init', 'twentytwentyfive_child_register_blocks' );

--- a/twentytwentyfive-child/style.css
+++ b/twentytwentyfive-child/style.css
@@ -1,0 +1,7 @@
+/*
+Theme Name: Twenty Twenty-Five Child
+Description: Enfant de Twenty Twenty-Five avec blocs personnalisés Slider et Crossroad Pages.
+Author: Codex
+Template: twentytwentyfive
+Version: 1.0.0
+*/

--- a/twentytwentyfive-child/theme.json
+++ b/twentytwentyfive-child/theme.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 2,
+    "settings": {
+        "color": {
+            "palette": [
+                { "slug": "primary", "color": "#0073aa", "name": "Primary" }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create Twenty Twenty-Five child theme
- register two custom Gutenberg blocks
- implement Slider block with simple JS slider
- implement Crossroad Pages block to show selected pages
- update README with installation instructions

## Testing
- `php -l twentytwentyfive-child/blocks/slider/render.php`
- `php -l twentytwentyfive-child/blocks/crossroad-pages/render.php`
- `php -l twentytwentyfive-child/functions.php`

------
https://chatgpt.com/codex/tasks/task_e_687c29788f608322aa670edbc0efc335