### PR TITLE
Improve Crossroad Pages block UI

### DIFF
--- a/blocks/crossroad-pages/block.json
+++ b/blocks/crossroad-pages/block.json
@@ -12,8 +12,11 @@
     "render": "file:./render.php",
     "attributes": {
         "pages": {
-            "type": "string",
-            "default": ""
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "default": []
         }
     }
 }

--- a/blocks/crossroad-pages/index.js
+++ b/blocks/crossroad-pages/index.js
@@ -1,23 +1,93 @@
-( function( blocks, element ) {
+/**
+ * Block for selecting pages to display as a grid of links.
+ *
+ * The editor UI mimics the Navigation block behaviour: a button "+" opens the
+ * WordPress link search popover allowing the user to pick a page. Selected
+ * pages are shown as small previews.
+ */
+( function( blocks, element, data, components, blockEditor ) {
     var el = element.createElement;
+    var useState = element.useState;
+    var useSelect = data.useSelect;
+    var Button = components.Button;
+    var Popover = components.Popover;
+    var LinkControl = blockEditor.LinkControl || blockEditor.__experimentalLinkControl;
+
+    function PagePreview( props ) {
+        var id = props.id;
+        var record = useSelect( function( select ) {
+            var page = select( 'core' ).getEntityRecord( 'postType', 'page', id );
+            var media = page && page.featured_media ? select( 'core' ).getMedia( page.featured_media ) : null;
+            return { page: page, media: media };
+        }, [ id ] );
+
+        if ( ! record.page ) {
+            return el( 'div', { className: 'crossroad-page loading', key: id }, '...' );
+        }
+
+        var style = {};
+        if ( record.media && record.media.source_url ) {
+            style.backgroundImage = 'url(' + record.media.source_url + ')';
+        }
+
+        return el( 'div', { className: 'crossroad-page', style: style, key: id },
+            el( 'span', { className: 'crossroad-page-title' }, record.page.title.rendered )
+        );
+    }
+
     blocks.registerBlockType( 'twentytwentyfive-child/crossroad-pages', {
         title: 'Crossroad Pages',
         icon: 'grid-view',
         category: 'widgets',
         attributes: {
-            pages: { type: 'string', default: '' }
+            pages: {
+                type: 'array',
+                items: { type: 'number' },
+                default: []
+            }
         },
         edit: function( props ) {
-            return el( 'input', {
-                type: 'text',
-                value: props.attributes.pages,
-                placeholder: 'IDs des pages séparées par une virgule',
-                onChange: function( event ) {
-                    props.setAttributes( { pages: event.target.value } );
-                },
-                style: { width: '100%' }
-            } );
+            var pages = props.attributes.pages || [];
+            var setAttributes = props.setAttributes;
+
+            var _useState = useState( false ),
+                isOpen = _useState[0],
+                setOpen = _useState[1];
+
+            function addPage( value ) {
+                if ( value && value.id ) {
+                    setAttributes( { pages: pages.concat( value.id ) } );
+                }
+                setOpen( false );
+            }
+
+            return el( 'div', {},
+                el( 'div', { className: 'crossroad-pages' },
+                    pages.map( function( id ) {
+                        return el( PagePreview, { id: id, key: id } );
+                    } ),
+                    el( Button, {
+                        icon: 'plus',
+                        onClick: function() { setOpen( true ); },
+                        variant: 'primary'
+                    } )
+                ),
+                isOpen && el( Popover, { position: 'bottom', onClose: function() { setOpen( false ); } },
+                    el( LinkControl, {
+                        onChange: addPage,
+                        searchInputPlaceholder: 'Rechercher une page',
+                        kind: 'post-type',
+                        type: 'page'
+                    } )
+                )
+            );
         },
         save: function() { return null; }
     } );
-} )( window.wp.blocks, window.wp.element );
+} )(
+    window.wp.blocks,
+    window.wp.element,
+    window.wp.data,
+    window.wp.components,
+    window.wp.blockEditor
+);

--- a/blocks/crossroad-pages/render.php
+++ b/blocks/crossroad-pages/render.php
@@ -1,5 +1,6 @@
 <?php
-$ids = array_filter( array_map( 'intval', explode( ',', $attributes['pages'] ?? '' ) ) );
+$ids = array_map( 'intval', $attributes['pages'] ?? [] );
+$ids = array_filter( $ids );
 if ( empty( $ids ) ) {
     return '';
 }
@@ -15,11 +16,14 @@ ob_start();
 ?>
 <div class="crossroad-pages">
 <?php while ( $query->have_posts() ) : $query->the_post(); ?>
-    <article class="crossroad-page">
-        <?php if ( has_post_thumbnail() ) : ?>
-            <a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'medium' ); ?></a>
-        <?php endif; ?>
-        <h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+    <?php
+        $thumb_url = get_the_post_thumbnail_url( get_the_ID(), 'medium' );
+        $style = $thumb_url ? sprintf( ' style="background-image:url(%s)"', esc_url( $thumb_url ) ) : '';
+    ?>
+    <article class="crossroad-page"<?php echo $style; ?>>
+        <a class="crossroad-page-link" href="<?php the_permalink(); ?>">
+            <h2 class="crossroad-page-title"><?php the_title(); ?></h2>
+        </a>
     </article>
 <?php endwhile; ?>
 </div>

--- a/blocks/crossroad-pages/style.css
+++ b/blocks/crossroad-pages/style.css
@@ -1,4 +1,25 @@
 .crossroad-pages { display: flex; flex-wrap: wrap; gap: 1rem; }
-.crossroad-page { width: calc(33.333% - 1rem); box-sizing: border-box; }
-.crossroad-page img { width: 100%; height: auto; display: block; }
-.crossroad-page h2 { font-size: 1.25rem; margin-top: 0.5rem; }
+.crossroad-page {
+    width: calc(33.333% - 1rem);
+    padding-top: 33.333%;
+    position: relative;
+    background-size: cover;
+    background-position: center;
+    color: #fff;
+}
+.crossroad-page-link {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    text-decoration: none;
+    color: inherit;
+}
+.crossroad-page-title {
+    background: rgba(0,0,0,0.5);
+    width: 100%;
+    margin: 0;
+    padding: 0.5rem;
+    text-align: center;
+    box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- add array attribute for Crossroad Pages block
- replace text field by LinkControl popover for selecting pages
- display page preview in editor and adjust frontend markup
- style Crossroad Pages to show square layout with overlay title

## Testing
- `php -l blocks/crossroad-pages/render.php`


------
https://chatgpt.com/codex/tasks/task_e_687c35bb6b54832283d5bcff2bf9d43b